### PR TITLE
Change overlay layer to ABOVE_SCENE

### DIFF
--- a/src/main/java/com/foo/NextActionOverlay.java
+++ b/src/main/java/com/foo/NextActionOverlay.java
@@ -30,7 +30,7 @@ public class NextActionOverlay extends Overlay {
 
         setPosition(OverlayPosition.DYNAMIC);
         setPriority(OverlayPriority.HIGH);
-        setLayer(OverlayLayer.ALWAYS_ON_TOP);
+        setLayer(OverlayLayer.ABOVE_SCENE);
     }
 
     @Override


### PR DESCRIPTION
Currently the overlay renders above everything else, sometimes obstructing the view of other interface elements. This PR fixes that problem.

Example:
<img width="989" height="625" alt="image" src="https://github.com/user-attachments/assets/3b4d4782-e4c3-434a-a4cd-98767508d63a" />
